### PR TITLE
feat: add sort panel and sorting

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1181,6 +1181,7 @@ function renderSortPanel() {
     radio.addEventListener('change', () => {
       filters.sort = opt.key;
       sortVenues();
+      filterVenues();
       renderFilters();
       maybeShowReset();
       closeSortPanel();

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   </button>
 </div>
 
-<!-- Pill Filters: rendered dynamically -->
+<!-- Pill Filters: rendered dynamically (Price, Suburb, Day, Sort) -->
 <div id="pillFilters" class="flex items-center flex-nowrap px-4 py-2 w-full gap-1"></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add Sort pill with bottom sheet panel for ordering venues
- implement sorting logic for name, price, and suburb with price-missing handling
- integrate sort state into reset flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ed3750eb4832c8cb7d054ea94312d